### PR TITLE
Fix: handle bad requests during job creation

### DIFF
--- a/internal/async_helpers.go
+++ b/internal/async_helpers.go
@@ -33,7 +33,11 @@ func (c *Client) GetJobID(
 	if err != nil {
 		return "", fmt.Errorf("error reading resp body: %v", err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("error with status code %s: %s", resp.Status, respBody)
+	}
 
 	// Unmarshal into job.
 	job := &Job{}


### PR DESCRIPTION
At the moment, if user provides invalid data that isn't caught during request validation, then SDK client will hang until timeout is reached.
Since API returns `202 Accepted`, status code should be checked when trying to `GetJobID()`.

These changes check response status code. In case of an error, response body is included in the error so the user knows what was the issue.