### PR TITLE
Feature: parse instructions validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,70 @@ res, err := c.ScrapeGoogleSearch(
 	"adidas",
 	&serp.GoogleSearchOpts{
 		Parse: true,
-		Context: []func(serp.ContextOption){
-			serp.ResultsLanguage("en"),
-			serp.Filter(1),
-			serp.Tbm("isch"),
-			serp.LimitPerPage([]serp.PageLimit{{Page: 1, Limit: 1}, {Page: 2, Limit: 6}}),
+		Context: []func(oxylabs.ContextOption){
+			oxylabs.ResultsLanguage("en"),
+			oxylabs.Filter(1),
+			oxylabs.Tbm("isch"),
+			oxylabs.LimitPerPage([]serp.PageLimit{{Page: 1, Limit: 1}, {Page: 2, Limit: 6}}),
 		},
 	},
 )
+```
+
+### Parse instructions
+
+SDK supports [custom parsing](https://developers.oxylabs.io/scraper-apis/custom-parser). 
+There are 2 ways to provide `parsing_instructions` `_fns`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mslmio/oxylabs-sdk-go/ecommerce"
+	"github.com/mslmio/oxylabs-sdk-go/oxylabs"
+)
+
+func main() {
+	const username = "username"
+	const password = "password"
+
+	// Initialize the SERP push-pull client with your credentials.
+	c := ecommerce.InitAsync(username, password)
+
+	ch, err := c.ScrapeUniversalUrl(
+		"https://example.com",
+		&ecommerce.UniversalUrlOpts{
+			Parse: true,
+			ParseInstructions: &map[string]interface{}{
+				"title": map[string]interface{}{
+					// Providing `_fns` as a map[string]interface{}.
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   oxylabs.Xpath,
+							"_args": []string{"//h1/text()"},
+						},
+					},
+				},
+				"second_paragraph": map[string]interface{}{
+					// Providing `_fns` as a `[]oxylabs.Fn`.
+					"_fns": []oxylabs.Fn{
+						{
+							Name: oxylabs.Xpath,
+							Args: []string{"/html/body/div/p[2]"},
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	res := <-ch
+	fmt.Println(res)
+}
 ```
 
 ## Integration Methods

--- a/ecommerce/amazon.go
+++ b/ecommerce/amazon.go
@@ -30,6 +30,12 @@ func (opt *AmazonUrlOpts) checkParameterValidity() error {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -137,6 +143,12 @@ func (opt *AmazonSearchOpts) checkParameterValidity() error {
 
 	if opt.Pages <= 0 || opt.StartPage <= 0 {
 		return fmt.Errorf("pages and start_page parameters must be greater than 0")
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil
@@ -259,6 +271,12 @@ func (opt *AmazonProductOpts) checkParameterValidity() error {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -376,6 +394,12 @@ func (opt *AmazonPricingOpts) checkParameterValidity() error {
 		return fmt.Errorf("pages and start_page parameters must be greater than 0")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -485,6 +509,12 @@ func (opt *AmazonReviewsOpts) checkParameterValidity() error {
 		return fmt.Errorf("pages and start_page parameters must be greater than 0")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -586,6 +616,12 @@ func (opt *AmazonQuestionsOpts) checkParameterValidity() error {
 
 	if opt.Render != "" && !oxylabs.IsRenderValid(opt.Render) {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil
@@ -693,6 +729,12 @@ func (opt *AmazonBestsellersOpts) checkParameterValidity() error {
 		return fmt.Errorf("pages and start_page parameters must be greater than 0")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -794,6 +836,12 @@ func (opt *AmazonSellersOpts) checkParameterValidity() error {
 
 	if opt.Render != "" && !oxylabs.IsRenderValid(opt.Render) {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil

--- a/ecommerce/google_shopping.go
+++ b/ecommerce/google_shopping.go
@@ -39,6 +39,12 @@ func (opt *GoogleShoppingUrlOpts) checkParameterValidity() error {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -158,6 +164,12 @@ func (opt *GoogleShoppingSearchOpts) checkParameterValidity(ctx oxylabs.ContextO
 	if (ctx["min_price"] != nil || ctx["max_price"] != nil) &&
 		(ctx["min_price"].(int) < 0 || ctx["max_price"].(int) < 0) {
 		return fmt.Errorf("min and max prices should be greater than 0")
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil
@@ -294,6 +306,12 @@ func (opt *GoogleShoppingProductOpts) checkParameterValidity() error {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -403,6 +421,12 @@ func (opt *GoogleShoppingPricingOpts) checkParameterValidity() error {
 
 	if opt.Pages <= 0 || opt.StartPage <= 0 {
 		return fmt.Errorf("pages and start_page parameters must be greater than 0")
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil

--- a/ecommerce/universal.go
+++ b/ecommerce/universal.go
@@ -44,6 +44,12 @@ func (opt *UniversalUrlOpts) checkParametersValidity(ctx oxylabs.ContextOption) 
 		return fmt.Errorf("content is useful only if http method is post")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/ecommerce/wayfair.go
+++ b/ecommerce/wayfair.go
@@ -24,6 +24,12 @@ func (opt *WayfairSearchOpts) checkParametersValidity() error {
 		return fmt.Errorf("invalid limit parameter: %v", opt.Limit)
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -126,6 +132,12 @@ type WayfairUrlOpts struct {
 func (opt *WayfairUrlOpts) checkParametersValidity() error {
 	if !oxylabs.IsUserAgentValid(opt.UserAgent) {
 		return fmt.Errorf("invalid user agent parameter: %v", opt.UserAgent)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/mslmio/oxylabs-sdk-go
 
 go 1.21.0
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/oxylabs/parse_instructions.go
+++ b/oxylabs/parse_instructions.go
@@ -1,0 +1,230 @@
+package oxylabs
+
+import "fmt"
+
+type FnName string
+
+const (
+	ElementText FnName = "element_text"
+	Xpath       FnName = "xpath"
+	XpathOne    FnName = "xpath_one"
+	Css         FnName = "css"
+	CssOne      FnName = "css_one"
+
+	AmountFromString      FnName = "amount_from_string"
+	AmountRangeFromString FnName = "amount_range_from_string"
+	Join                  FnName = "join"
+	RegexFindAll          FnName = "regex_find_all"
+	RegexSearch           FnName = "regex_search"
+	RegexSubstring        FnName = "regex_substring"
+
+	Length         FnName = "length"
+	SelectNth      FnName = "select_nth"
+	ConvertToFloat FnName = "convert_to_float"
+	ConvertToInt   FnName = "convert_to_int"
+	ConvertToStr   FnName = "convert_to_str"
+
+	Average FnName = "average"
+	Max     FnName = "max"
+	Min     FnName = "min"
+	Product FnName = "product"
+)
+
+type Fn struct {
+	Name FnName `json:"_fn"`
+	Args any    `json:"_args,omitempty"`
+}
+
+func ValidateParseInstructions(instructions *map[string]interface{}) error {
+	if instructions == nil {
+		return fmt.Errorf("parse instructions cannot be nil")
+	}
+
+	for k, v := range *instructions {
+		switch k {
+		case "_fns":
+			if err := validateFns(v); err != nil {
+				return err
+			}
+		default:
+			vv, ok := v.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("invalid parse instructions format")
+			}
+			if err := ValidateParseInstructions(&vv); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateFns(fns interface{}) error {
+	if fns == nil {
+		return fmt.Errorf("_fns cannot be nil")
+	}
+	switch v := fns.(type) {
+	case []Fn:
+		for _, f := range v {
+			if err := validateFn(f); err != nil {
+				return err
+			}
+		}
+	case []map[string]interface{}:
+		for _, f := range v {
+			fnName, ok := f["_fn"]
+			if !ok {
+				return fmt.Errorf("_fn must be set")
+			}
+			switch v := fnName.(type) {
+			case string:
+				if err := validateFn(Fn{Name: FnName(v), Args: f["_args"]}); err != nil {
+					return err
+				}
+			case FnName:
+				if err := validateFn(Fn{Name: v, Args: f["_args"]}); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("_fn must be string")
+			}
+		}
+	default:
+		return fmt.Errorf("invalid _fns format")
+	}
+
+	return nil
+}
+
+func validateFn(fn Fn) error {
+	var err error
+	switch fn.Name {
+	case "":
+		return fmt.Errorf("_fn cannot be empty")
+	case ElementText, Length, ConvertToFloat, ConvertToInt, ConvertToStr, Max, Min, Product:
+		err = validateEmpty(fn.Args)
+	case Xpath, XpathOne, Css, CssOne:
+		err = validateStringArray(fn.Args)
+	case AmountFromString, AmountRangeFromString, RegexFindAll:
+		err = validateString(fn.Args)
+	case Join:
+		err = validateOptionalString(fn.Args)
+	case RegexSearch, RegexSubstring:
+		err = validateListStringOptionalInt(fn.Args)
+	case SelectNth:
+		err = validateNonZeroInt(fn.Args)
+	case Average:
+		err = validateOptionalInt(fn.Args)
+	}
+
+	if err != nil {
+		return fmt.Errorf("_fn %s invalid: %w", fn.Name, err)
+	}
+	return nil
+}
+
+func isEmpty(args any) bool {
+	return args == nil
+}
+
+func validateEmpty(args any) error {
+	if !isEmpty(args) {
+		return fmt.Errorf("_args must be empty")
+	}
+
+	return nil
+}
+
+func validateStringArray(args any) error {
+	a, ok := args.([]string)
+	if !ok {
+		return fmt.Errorf("_args must be of type []string")
+	}
+	if len(a) < 1 {
+		return fmt.Errorf("_args cannot be empty")
+	}
+	for _, e := range a {
+		if e == "" {
+			return fmt.Errorf("_args cannot have empty elements")
+		}
+	}
+
+	return nil
+}
+
+func validateString(args any) error {
+	arg, ok := args.(string)
+	if !ok {
+		return fmt.Errorf("_args must be of type string")
+	}
+	if arg == "" {
+		return fmt.Errorf("_args cannot be empty")
+	}
+
+	return nil
+}
+
+func validateOptionalString(args any) error {
+	if isEmpty(args) {
+		return nil
+	}
+
+	_, ok := args.(string)
+	if !ok {
+		return fmt.Errorf("_args must be of type string")
+	}
+
+	return nil
+}
+
+func validateNonZeroInt(args any) error {
+	arg, ok := args.(int)
+	if !ok {
+		return fmt.Errorf("_args must be of type int")
+	}
+	if arg == 0 {
+		return fmt.Errorf("_args cannot be 0")
+	}
+
+	return nil
+}
+
+func validateOptionalInt(args any) error {
+	if isEmpty(args) {
+		return nil
+	}
+
+	_, ok := args.(int)
+	if !ok {
+		return fmt.Errorf("_args must be of type int")
+	}
+
+	return nil
+}
+
+func validateListStringOptionalInt(args any) error {
+	a, ok := args.([]any)
+	if !ok {
+		return fmt.Errorf("_args must be non empty list of arguments")
+	}
+
+	arg, ok := a[0].(string)
+	if !ok {
+		return fmt.Errorf("_args first argument must be string")
+	}
+	if arg == "" {
+		return fmt.Errorf("_args first argument cannot be empty")
+	}
+
+	if len(a) < 2 {
+		return nil
+	}
+
+	_, ok = a[1].(int)
+	if !ok {
+		return fmt.Errorf("_args second argument must be int")
+	}
+
+	return nil
+}

--- a/oxylabs/parse_instructions_test.go
+++ b/oxylabs/parse_instructions_test.go
@@ -1,0 +1,698 @@
+package oxylabs
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidateParseInstructions_EmptyArgs(t *testing.T) {
+	fnNames := []string{"element_text", "length", "convert_to_float", "convert_to_int", "convert_to_str", "max", "min", "product"}
+	for _, fnName := range fnNames {
+		type args struct {
+			instructions *map[string]interface{}
+		}
+		tests := []struct {
+			name    string
+			args    args
+			wantErr bool
+		}{
+			{
+				name: fmt.Sprintf("%s with no args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn": fnName,
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "unnecessary arg",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with no args Fn struct", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []Fn{{
+						Name: FnName(fnName),
+					}},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with args Fn struct", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []Fn{{
+						Name: FnName(fnName),
+						Args: "unnecessary arg",
+					}},
+				}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := ValidateParseInstructions(tt.args.instructions); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateParseInstructions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateParseInstructions_StringArrayArgs(t *testing.T) {
+	fnNames := []string{"xpath", "xpath_one", "css", "css_one"}
+	for _, fnName := range fnNames {
+		type args struct {
+			instructions *map[string]interface{}
+		}
+		tests := []struct {
+			name    string
+			args    args
+			wantErr bool
+		}{
+			{
+				name: fmt.Sprintf("%s with no args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn": fnName,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []string{"1st arg"},
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with 2 string args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []string{"1st arg", "2nd string"},
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 empty arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []string{""},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid type args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"string", 1},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with empty list of args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []string{},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := ValidateParseInstructions(tt.args.instructions); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateParseInstructions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateParseInstructions_StringArg(t *testing.T) {
+	fnNames := []string{"amount_from_string", "amount_range_from_string", "regex_find_all"}
+	for _, fnName := range fnNames {
+		type args struct {
+			instructions *map[string]interface{}
+		}
+		tests := []struct {
+			name    string
+			args    args
+			wantErr bool
+		}{
+			{
+				name: fmt.Sprintf("%s with no args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn": fnName,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "1st arg",
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with empty string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with int arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": 1,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid type args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"string", 1},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := ValidateParseInstructions(tt.args.instructions); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateParseInstructions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateParseInstructions_OptionalStringArgs(t *testing.T) {
+	fnNames := []string{"join"}
+	for _, fnName := range fnNames {
+		type args struct {
+			instructions *map[string]interface{}
+		}
+		tests := []struct {
+			name    string
+			args    args
+			wantErr bool
+		}{
+			{
+				name: fmt.Sprintf("%s with no args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn": fnName,
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "1st arg",
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with empty string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "",
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with int arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": 1,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid type args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"string", 1},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := ValidateParseInstructions(tt.args.instructions); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateParseInstructions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateParseInstructions_ListStringOptionalIntArgs(t *testing.T) {
+	fnNames := []string{"regex_search", "regex_substring"}
+	for _, fnName := range fnNames {
+		type args struct {
+			instructions *map[string]interface{}
+		}
+		tests := []struct {
+			name    string
+			args    args
+			wantErr bool
+		}{
+			{
+				name: fmt.Sprintf("%s with no args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn": fnName,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "1st arg",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 string arg in a list", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"1st arg"},
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with empty string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with int arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": 1,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with valid string and int args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"string", 1},
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid type args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"string", "1"},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid list of args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{1, "1"},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid list of args with empty string", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{""},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := ValidateParseInstructions(tt.args.instructions); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateParseInstructions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateParseInstructions_IntArg(t *testing.T) {
+	fnNames := []string{"select_nth"}
+	for _, fnName := range fnNames {
+		type args struct {
+			instructions *map[string]interface{}
+		}
+		tests := []struct {
+			name    string
+			args    args
+			wantErr bool
+		}{
+			{
+				name: fmt.Sprintf("%s with no args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn": fnName,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "1st arg",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with empty string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with int arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": 1,
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with 0 int arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": 0,
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid type args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"string", 1},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := ValidateParseInstructions(tt.args.instructions); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateParseInstructions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateParseInstructions_OptionalIntArg(t *testing.T) {
+	fnNames := []string{"average"}
+	for _, fnName := range fnNames {
+		type args struct {
+			instructions *map[string]interface{}
+		}
+		tests := []struct {
+			name    string
+			args    args
+			wantErr bool
+		}{
+			{
+				name: fmt.Sprintf("%s with no args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn": fnName,
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with 1 string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "1st arg",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with empty string arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": "",
+						},
+					},
+				}},
+				wantErr: true,
+			},
+			{
+				name: fmt.Sprintf("%s with int arg", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": 0,
+						},
+					},
+				}},
+				wantErr: false,
+			},
+			{
+				name: fmt.Sprintf("%s with invalid type args", fnName),
+				args: args{instructions: &map[string]interface{}{
+					"_fns": []map[string]interface{}{
+						{
+							"_fn":   fnName,
+							"_args": []interface{}{"string", 1},
+						},
+					},
+				}},
+				wantErr: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := ValidateParseInstructions(tt.args.instructions); (err != nil) != tt.wantErr {
+					t.Errorf("ValidateParseInstructions() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateParseInstructions_NilInstructions(t *testing.T) {
+	err := ValidateParseInstructions(nil)
+	assert.Error(t, err)
+}
+
+func TestValidateParseInstructions_MissingFn(t *testing.T) {
+	err := ValidateParseInstructions(&map[string]interface{}{
+		"element": "invalid item",
+	})
+	assert.Error(t, err)
+}
+
+func TestValidateParseInstructions_InvalidInstructions(t *testing.T) {
+	err := ValidateParseInstructions(&map[string]interface{}{
+		"element": map[string]interface{}{
+			"_fns": []map[string]interface{}{
+				{
+					"element": "invalid item",
+				},
+			},
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestValidateParseInstructions_EmptyFn(t *testing.T) {
+	err := ValidateParseInstructions(&map[string]interface{}{
+		"element": map[string]interface{}{
+			"_fns": []map[string]interface{}{
+				{
+					"_fn": "",
+				},
+			},
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestValidateParseInstructions_NilFns(t *testing.T) {
+	err := ValidateParseInstructions(&map[string]interface{}{
+		"element": map[string]interface{}{
+			"_fns": nil,
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestValidateParseInstructions_InvalidFnType(t *testing.T) {
+	err := ValidateParseInstructions(&map[string]interface{}{
+		"element": map[string]interface{}{
+			"_fns": []map[string]interface{}{
+				{
+					"_fn": 1,
+				},
+			},
+		},
+	})
+	assert.Error(t, err)
+}
+
+func TestValidateParseInstructions_InvalidFnsFormat(t *testing.T) {
+	err := ValidateParseInstructions(&map[string]interface{}{
+		"element": map[string]interface{}{
+			"_fns": map[string]interface{}{},
+		},
+	})
+	assert.Error(t, err)
+}

--- a/serp/baidu.go
+++ b/serp/baidu.go
@@ -30,6 +30,12 @@ func (opt *BaiduSearchOpts) checkParameterValidity() error {
 		return fmt.Errorf("limit, pages and start_page parameters must be greater than 0")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -37,6 +43,12 @@ func (opt *BaiduSearchOpts) checkParameterValidity() error {
 func (opt *BaiduUrlOpts) checkParameterValidity() error {
 	if !oxylabs.IsUserAgentValid(opt.UserAgent) {
 		return fmt.Errorf("invalid user agent parameter: %v", opt.UserAgent)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil

--- a/serp/bing.go
+++ b/serp/bing.go
@@ -38,6 +38,12 @@ func (opt *BingSearchOpts) checkParameterValidity() error {
 		return fmt.Errorf("limit, pages and start_page parameters must be greater than 0")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -49,6 +55,12 @@ func (opt *BingUrlOpts) checkParameterValidity() error {
 
 	if opt.Render != "" && !oxylabs.IsRenderValid(opt.Render) {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil

--- a/serp/google.go
+++ b/serp/google.go
@@ -48,6 +48,12 @@ func (opt *GoogleSearchOpts) checkParameterValidity(ctx oxylabs.ContextOption) e
 		return fmt.Errorf("invalid tbm parameter: %v", ctx["tbm"])
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -59,6 +65,12 @@ func (opt *GoogleUrlOpts) checkParameterValidity() error {
 
 	if opt.Render != "" && !oxylabs.IsRenderValid(opt.Render) {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil
@@ -82,6 +94,12 @@ func (opt *GoogleAdsOpts) checkParameterValidity(ctx oxylabs.ContextOption) erro
 		return fmt.Errorf("invalid tbm parameter: %v", ctx["tbm"])
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -93,6 +111,12 @@ func (opt *GoogleSuggestionsOpts) checkParameterValidity() error {
 
 	if opt.Render != "" && !oxylabs.IsRenderValid(opt.Render) {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil
@@ -114,6 +138,12 @@ func (opt *GoogleHotelsOpts) checkParameterValidity(ctx oxylabs.ContextOption) e
 
 	if ctx["hotel_occupancy"] != nil && ctx["hotel_occupancy"].(int) < 0 {
 		return fmt.Errorf("invalid hotel_occupancy parameter: %v", ctx["hotel_occupancy"])
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil
@@ -145,6 +175,12 @@ func (opt *GoogleTravelHotelsOpts) checkParameterValidity(ctx oxylabs.ContextOpt
 		}
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -162,10 +198,16 @@ func (opt *GoogleTrendsExploreOpts) checkParameterValidity(ctx oxylabs.ContextOp
 		return fmt.Errorf("invalid category_id")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
-// checkParameterValidity checks validity of google images parameters.
+// checkParameterValidity checks validity of ScrapeGoogleImages parameters.
 func (opt *GoogleImagesOpts) checkParameterValidity() error {
 	if opt.Render != "" && !oxylabs.IsRenderValid(opt.Render) {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
@@ -173,6 +215,12 @@ func (opt *GoogleImagesOpts) checkParameterValidity() error {
 
 	if opt.Pages <= 0 || opt.StartPage <= 0 {
 		return fmt.Errorf("pages and start_page parameters must be greater than 0")
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil

--- a/serp/yandex.go
+++ b/serp/yandex.go
@@ -50,6 +50,12 @@ func (opt *YandexSearchOpts) checkParameterValidity() error {
 		return fmt.Errorf("limit, pages and start_page parameters must be greater than 0")
 	}
 
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -61,6 +67,12 @@ func (opt *YandexUrlOpts) checkParameterValidity() error {
 
 	if opt.Render != "" && !oxylabs.IsRenderValid(opt.Render) {
 		return fmt.Errorf("invalid render parameter: %v", opt.Render)
+	}
+
+	if opt.ParseInstructions != nil {
+		if err := oxylabs.ValidateParseInstructions(opt.ParseInstructions); err != nil {
+			return fmt.Errorf("invalid parse instructions: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
In order to make SDK more robust, I propose adding additional validation for parse instructions. 
Before making actual request, basic parse instruction validation would be performed by SDK, which will fail faster if user provides incorrect instructions, compared to making API request.

In addition new `structs` and `const` will make it easier to use parsing instructions, but old format is still supported, so there is no backwards incompatibility. 