### PR TITLE
fix: url construction in proxy Init 

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -12,12 +12,16 @@ func Init(
 	username string,
 	password string,
 ) (*http.Client, error) {
+	// Encode username and password.
+	encodedUsername := url.QueryEscape(username)
+	encodedPassword := url.QueryEscape(password)
+
 	// Prepare proxy URL.
 	proxyUrl, err := url.Parse(
 		fmt.Sprintf(
 			"http://%s:%s@realtime.oxylabs.io:60000",
-			username,
-			password,
+			encodedUsername,
+			encodedPassword,
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
Previously, the URL parsing would throw an error if the username/password contained special characters such as '#'. However, these characters are allowed for the API user credentials. 